### PR TITLE
Simply `GNUmakefile` and add support for ARM64

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,25 +1,12 @@
-GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 PKG_NAME=elephantsql
 PROVIDER_VERSION = 0.0.1
 
 default: build
 
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Linux)
-	GOOS += linux
-else ifeq ($(UNAME_S),Darwin)
-	GOOS += darwin
-endif
-
-UNAME_M := $(shell uname -m)
-ifeq ($(UNAME_M),x86_64)
-	GOARCH += amd64
-else ifeq ($(UNAME_M),arm64)
-	GOARCH += arm64
-else ifeq ($(UNAME_M),aarch64)
-	GOARCH += arm64
-endif
-PROVIDER_ARCH = $(GOOS)_$(GOARCH)
+GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
+PROVIDER_ARCH := $(GOOS)_$(GOARCH)
 
 tools:
 	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
@@ -32,9 +19,7 @@ local-clean:
 	rm -rf ~/.terraform.d/plugins/localhost/elephantsql/elephantsql/$(PROVIDER_VERSION)/$(PROVIDER_ARCH)/terraform-provider-elephantsql_v$(PROVIDER_VERSION)
 
 local-build: local-clean
-	@echo $(GOOS);
-	@echo $(GOARCH);
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X 'main.version=$(PROVIDER_VERSION)'" -o terraform-provider-elephantsql_v$(PROVIDER_VERSION)
+	go build -ldflags "-X 'main.version=$(PROVIDER_VERSION)'" -o terraform-provider-elephantsql_v$(PROVIDER_VERSION)
 
 local-install: local-build
 	mkdir -p ~/.terraform.d/plugins/localhost/elephantsql/elephantsql/$(PROVIDER_VERSION)/$(PROVIDER_ARCH)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,28 +4,20 @@ PROVIDER_VERSION = 0.0.1
 
 default: build
 
-## Check if a 64 bit kernel is running
-UNAME_M := $(shell uname -m)
-
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	GOOS += linux
-endif
-ifeq ($(UNAME_S),Darwin)
+else ifeq ($(UNAME_S),Darwin)
 	GOOS += darwin
 endif
 
-UNAME_P := $(shell uname -p)
-ifeq ($(UNAME_P),i386)
-	ifeq ($(UNAME_M),x86_64)
-		GOARCH += amd64
-	else
-		GOARCH += i386
-	endif
-else
-	ifeq ($(UNAME_P),AMD64)
-	 GOARCH += amd64
-	endif
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+	GOARCH += amd64
+else ifeq ($(UNAME_M),arm64)
+	GOARCH += arm64
+else ifeq ($(UNAME_M),aarch64)
+	GOARCH += arm64
 endif
 PROVIDER_ARCH = $(GOOS)_$(GOARCH)
 


### PR DESCRIPTION
See individual commits. Just the simplification of the `GNUmakefile` would do the trick, but I deemed it to be some value in keeping the commit message of the fist commit.

---

Investigation of the different values of `uname` for different combinations (not really relevant after simplification of makefile, but consider it fun facts):

| system             | `uname -m` | `uname -s` | `uname -p` |
|--------------------|------------|------------|------------|
| macOS 13.1 (M1) | arm64 | Darwin | arm |
| macOS 13.1 (Intel) | x86_64 | Darwin | i386 |
| Debian 11 (arm - container) | aarch64 | Linux | unknown |
| Ubuntu 18.04 (Intel) | x86_64 | Linux | x86_64 |
| Ubuntu 20.04 (Intel) | x86_64 | Linux | x86_64 |
| Debian 11 via Docker on macOS 13.1 (M1) with `--platform linux/arm64` | aarch64 | Linux | unknown |
| Debian 11 via Docker on macOS 13.1 (M1) with `--platform linux/amd64` | x86_64 | Linux | unknown |
| Debian 11 via WSL2 (Windows 11 in VMware on macOS 12.6.2 (Intel)) | x86_64 | Linux | unknown |
| Ubuntu 20.04 via Docker on macOS 13.1 (M1) with `--platform linux/arm64` | aarch64 | Linux | aarch64 |
| Ubuntu 20.04 via Docker on macOS 13.1 (M1) with `--platform linux/amd64` | x86_64 | Linux | x86_64 |
